### PR TITLE
CMakeLists.txt: switch to cmake-3.10 as minimal supported version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.10)
 project(diskscan
         VERSION 0.19)
 


### PR DESCRIPTION
Without the change the build on `cmake-4` fails as:

    CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
      Compatibility with CMake < 3.5 has been removed from CMake.